### PR TITLE
Mention AUR installation and add Arch Linux dependencies to Source Build instructions

### DIFF
--- a/src/getting_started/index.md
+++ b/src/getting_started/index.md
@@ -108,6 +108,14 @@ sudo apt install mcpelauncher-manifest mcpelauncher-ui-manifest msa-manifest
 sudo dnf install mcpelauncher-manifest mcpelauncher-ui-manifest msa-manifest
 ```
 
+### Arch User Repository (AUR) Package
+
+**Unofficial** packages for Arch Linux users can be installed on the AUR, both [client](https://aur.archlinux.org/packages/mcpelauncher-linux) and [Qt launcher](https://aur.archlinux.org/packages/mcpelauncher-ui). You can install using an appropriate AUR helper such as yay.
+
+``` bash
+yay -S mcpelauncher-linux mcpelauncher-ui
+```
+
 #### Run
 
 You can find it in the startmenu or run the following command

--- a/src/source_build/intro.md
+++ b/src/source_build/intro.md
@@ -7,6 +7,7 @@ prerequirements from below.
 
 - **Ubuntu** - `sudo apt-get install git cmake pkg-config`
 - **Fedora** - `sudo dnf install git make cmake pkg-config`
+- **Arch** - `sudo pacman -S git make cmake pkgconf`
 
 ## What to build
 

--- a/src/source_build/launcher.md
+++ b/src/source_build/launcher.md
@@ -8,6 +8,9 @@
 - **Fedora** (Up to date as of 2024-08-21) - you'll need to install the
   required packages:
   `sudo dnf install clang cmake make git ca-certificates libstdc++ glibc-devel libpng-devel zlib-devel libX11-devel libXi-devel libcurl-devel systemd-devel libevdev-devel mesa-libEGL-devel alsa-lib pulseaudio-libs mesa-dri-drivers systemd-devel libXtst-devel openssl-devel qt5-qtbase-devel qt5-qtwebengine-devel qt5-qtdeclarative-devel qt5-qtsvg-devel qt5-qtquickcontrols qt5-qtquickcontrols2`
+- **Arch** (Up to date as of 2024-12-02) - you'll need to install the 
+  required packages:
+  `sudo pacman -S sudo pacman -S gcc clang ca-certificates openssl libpng libx11 libxi gcc-libs glibc zlib curl systemd libevdev mesa alsa-lib pulseaudio libxtst qt5-base qt5-webengine qt5-declarative qt5-svg qt5-quickcontrols qt5-quickcontrols2`
 - **macOS** - you'll need to install the required packages:
   `brew install cmake libpng openssl@1.1 qt@5`
 

--- a/src/source_build/msa.md
+++ b/src/source_build/msa.md
@@ -13,6 +13,8 @@
   `apt-get install libssl-dev libcurl4-openssl-dev`
 - **Fedora** (Up to date as of 2024-08-21) -
   `sudo dnf install openssl-devel libcurl-devel qt5-qtbase-devel qt5-qtwebengine-devel`
+- **Arch** (Up to date as of 2024-12-02) - 
+  `sudo pacman -S openssl curl qt5-base qt5-webengine`
 - **macOS** - `brew install cmake qt@5`
 
 ## Build instructions

--- a/src/source_build/ui.md
+++ b/src/source_build/ui.md
@@ -13,6 +13,8 @@
   `apt-get install libssl-dev libcurl4-openssl-dev libuv1-dev libzip-dev libprotobuf-dev protobuf-compiler`
 - **Fedora** (Up to date as of 2024-08-21)-
   `sudo dnf install libuv-devel libzip-devel protobuf-devel protobuf-compiler qt5-qtbase-devel qt5-qtwebengine-devel qt5-qtdeclarative-devel qt5-qtsvg-devel qt5-qtquickcontrols qt5-qtquickcontrols2 libcurl-devel libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel`
+- **Arch** (Up to date as of 2024-12-02)-
+  `sudo pacman -S openssl curl libuv libzip protobuf qt5-base qt5-webengine qt5-declarative qt5-svg qt5-quickcontrols qt5-quickcontrols2 qt5-tools libxrandr libxinerama libxcursor libxi`
 - **macOS** - `brew install cmake qt@5 libzip libuv protobuf`
 - [The Game Launcher](./launcher.md)
 


### PR DESCRIPTION
The purpose of this pull request is to improve the documentation by making the project more accessible to Arch Linux users. This is done in two ways:

1. Mention the unofficial AUR packages by @HurricanePootis and how they can be installed
2. Add Arch Linux equivalents to required dependencies of building the mcpelauncher components from source.

To ensure that the dependencies in Arch Linux are equivalent, I created a minimal Arch Linux distrobox image to install the dependencies and build mcpelauncher, msa, and the Qt UI completely from source. mcpelauncher and msa compiled flawlessly, but I did run into an issue related to an outdated C++ specification when compiling the Qt UI. I have raised this issue [here](https://github.com/minecraft-linux/mcpelauncher-ui-qt/issues/47). Bumping it up to 17 makes Qt UI compile flawlessly.
