### PR TITLE
Add documentation for enabling Native Wayland support and troubleshooting XWayland issues

### DIFF
--- a/src/source_build/launcher.md
+++ b/src/source_build/launcher.md
@@ -31,6 +31,11 @@ if you didn't install the MSA daemon (e.g. if you ran the previous
 command in `/home/paul/`, you'd have to use
 `/home/paul/msa/build/msa-daemon` as the path).
 
+### Adding Wayland support
+
+By default, compiling the game launcher will not come with native Wayland support, as SDL3 is not enabled. The game will run under Xwayland, but if you are running into issues (e.g. flickering, mouse not locked), it's best to run the game natively through Wayland. To compile the launcher using SDL3, add the following cmake flag:
+`-DGAMEWINDOW_SYSTEM=SDL3`
+
 ## Installation
 
 You can now optionally install the launcher system-wise. If you don't,

--- a/src/troubleshooting/index.md
+++ b/src/troubleshooting/index.md
@@ -98,6 +98,8 @@ your hardware.
 You may need to reinstall the proprietary drivers if you had installed
 them manually before.
 
+Performance can also degrade by [running under Xwayland](#i-am-running-into-glitches-with-xwayland).
+
 ### Black screen with Mesa 23.1+
 
 Try adding `MESA_EXTENSION_OVERRIDE=-GL_EXT_instanced_arrays` to
@@ -188,6 +190,30 @@ Mac OS X:
 - `cd /Applications/Minecraft\ Bedrock\ Launcher.app/Contents/MacOS`
 - `./mcpelauncher-client -dg ~/Library/Application\ Support/mcpelauncher/versions/1.2.3.4` -
   Replace 1.2.3.4 with the version of Minecraft you want to run.
+
+### I am running into glitches with Xwayland 
+
+Xwayland does a fairly good job of running X applications on Wayland, but it 
+is not perfect. Depending on your graphics drivers and your desktop environment/
+window manager, you will run into issues that will affect your experience.
+These issues are beyond the scope of this project and should be reported
+upstream. There are two solutions: Fallback to an X11 session, or run the game
+natively under Wayland.
+
+#### Run natively under Wayland
+
+By default, the binary does not come with native Wayland support. 
+You will need to [build the game launcher from source](../source_build/index.md) 
+with SDL3 to enable native wayland support.
+
+Once you have the game launcher built with Wayland support, you will need to
+force the client to run under Wayland, as it will still default to running 
+under Xwayland. This is done by unsetting the `DISPLAY` environment variable.
+
+Through the Qt Launcher, edit your profile and open up the
+advanced options. Under "Environment Variables", add a variable called
+`DISPLAY` (case-matching), and leave the value blank. Doing so will have the 
+client running under native Wayland.
 
 ## Qt launcher UI
 


### PR DESCRIPTION
This pull request helps document the issues that can arise from running the client under XWayland, and how to compile the game launcher with native Wayland support. I feel like the documentation does a much better job than #82 when it comes to this purpose, so merging this request should close that one.

I am aware of the [progress being made](https://github.com/minecraft-linux/mcpelauncher-manifest/pull/935) to try and get both the game launcher and the qt launcher to run under SDL3 by default, but considering how long the pull request has been open and I do not have any idea when this pull request will merge, it's important that we address the issue in the meantime.

Once that pull request does merge, the documentation can be further updated by removing the instructions and streamlining the troubleshooting process.